### PR TITLE
small fix - fixed warning cylinder to get complete rendering

### DIFF
--- a/hingebox_code.scad
+++ b/hingebox_code.scad
@@ -563,10 +563,10 @@ module base_box( d, top_inset=false, f=corner_fn ) {
     b=corner_radius;
     tb= top_inset ? top_inset : b;
     hull() {
-        translate( [b,b,0] ) cylinder( r=b, r2=tb, h=d.z, $fn=f );
-        translate( [b,d.y-b,0] ) cylinder( r=b, r2=tb,h=d.z, $fn=f  );
-        translate( [d.x-b,b,0] ) cylinder( r=b, r2=tb,h=d.z, $fn=f  );
-        translate( [d.x-b,d.y-b,0] ) cylinder( r=b, r2=tb,h=d.z, $fn=f  );
+        translate( [b,b,0] ) cylinder( r1=b, r2=tb, h=d.z, $fn=f );
+        translate( [b,d.y-b,0] ) cylinder( r1=b, r2=tb,h=d.z, $fn=f  );
+        translate( [d.x-b,b,0] ) cylinder( r1=b, r2=tb,h=d.z, $fn=f  );
+        translate( [d.x-b,d.y-b,0] ) cylinder( r1=b, r2=tb,h=d.z, $fn=f  );
     }
 }
 


### PR DESCRIPTION
The warning from L566 to L569 results in an error in rendering in the latest OpenSCAD tool (version 2021.01)

After changing `r` to `r1` warning goes away and rendering works.