### PR TITLE
Fix dividers with thick walls

### DIFF
--- a/hingebox_code.scad
+++ b/hingebox_code.scad
@@ -607,7 +607,7 @@ module hingedbox_half( bd, topflag=false ) {
     top_d = [dx-wt, dy-wt, wt];
     
     // inserts
-    ins_d=[ dx-wt2, dy-wt2, lz-wt2];
+    ins_d=[ dx-wt2, dy-wt2, lz-wt];
     
     // screw towers
     screw_id_bottom = (screw_id_bottom !=false)? screw_id_bottom : (screw_id*0.80);


### PR DESCRIPTION
Dividers would previously not go all the way to the top of the box, because the box inner outline subtraced twice the wall thickness from the z, even though z is special in that we don't need to consider the lid's thickness

before (example_partbox with wall_thick = 5):

![2024-04-27_22-47](https://github.com/sbambach/MarksEnclosureHelper/assets/5213469/435ba8cc-c8be-4ebc-aa98-f53b7ade14bd)

after:

![2024-04-27_22-49](https://github.com/sbambach/MarksEnclosureHelper/assets/5213469/d274174d-540b-478c-8c79-23ac848b7415)
